### PR TITLE
Refactor: remove empty variable and use empty? method for conditions

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,29 +1,18 @@
 class Cell
 
-  attr_reader :coordinate, :ship, :empty, :fired_upon
+  attr_reader :coordinate, :ship, :fired_upon
   def initialize(coordinate)
     @coordinate = coordinate
     @ship = ship
-    @empty = true
     @fired_upon = false
   end
 
   def empty?
-    if ship != nil
-      @empty = false
-    else
-      @empty = true
-    end
+    @ship.nil?
   end
-
-    # For empty?-- @ship.nil? <-- also works
-
-    # refactor notes - can get rid of the @empty var & use empty? in
-    # all instances of using @empty
 
   def place_ship(ship)
     @ship = ship
-    @empty = false
   end
 
   def fired_upon?
@@ -32,21 +21,21 @@ class Cell
 
   def fire_upon
     @fired_upon = true
-    if @ship != nil
+    if !empty?
       @ship.hit
     end
   end
 
   def render(reveal = false)
-    if reveal == true && @empty == false && @fired_upon == false
+    if reveal == true && !empty? && @fired_upon == false
       "S"
-    elsif @fired_upon == true && @empty == false && @ship.sunk?
+    elsif @fired_upon == true && !empty? && @ship.sunk?
       "X"
-    elsif @fired_upon == true && @empty == false && !@ship.sunk?
+    elsif @fired_upon == true && !empty? && !@ship.sunk?
       "H"
-    elsif @fired_upon == true && @empty == true
+    elsif @fired_upon == true && empty?
       "M"
-    elsif @fired_upon == false && @empty == true
+    elsif @fired_upon == false && empty?
       "."
     end
   end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Cell do
     end
   end
 
-  describe '#condition for dead ship' do
+  describe 'condition for dead ship' do
     cell_2 = Cell.new("C3")
     cruiser = Ship.new("Cruiser", 3)
 


### PR DESCRIPTION
This PR removes the empty variable( @empty) and replaces it with the empty? method results in place for where the variable was.